### PR TITLE
Safeguard against empty `Unicode` elements

### DIFF
--- a/page_to_text.py
+++ b/page_to_text.py
@@ -23,7 +23,8 @@ if sys.stdout.encoding != 'UTF-8':
         for regions in tree.iterfind('.//{%s}TextEquiv' % xmlns):
             sys.stdout.write('\n')
             for region in regions.findall('{%s}Unicode' % xmlns):
-                text = region.text
-                sys.stdout.write(text)
+                if region.text is not None:
+                    text = region.text
+                    sys.stdout.write(text)
     else:
         print('ERROR: Not a valid PAGE xml file (namespace declaration missing)')


### PR DESCRIPTION
This pull request makes sure that the script does not fail with the following error when the input XML document contains empty `Unicode` elements:

```
TypeError: utf_8_encode() argument 1 must be str, not NoneType
```